### PR TITLE
Add some support for more swaync features

### DIFF
--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -5,6 +5,21 @@
   transition: 200ms;
 }
 
+trough highlight {
+    background: $text;
+}
+
+scale trough {
+    margin: 0rem 1rem;
+    background-color: $surface0;
+    min-height: 8px;
+    min-width: 70px;
+}
+
+slider {
+    background-color: $blue;
+}
+
 .floating-notifications.background .notification-row .notification-background {
   box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.8), inset 0 0 0 1px $surface0;
   border-radius: 12.6px;
@@ -90,7 +105,7 @@
   padding: 14px;
 }
 
-.control-center .widget-title {
+.control-center .widget-title>label {
   color: $text;
   font-size: 1.3em;
 }
@@ -180,6 +195,10 @@
   background-color: $maroon;
 }
 
+.close-button {
+  border-radius: 6.3px;
+}
+
 .control-center .notification-row .notification-background .close-button:hover {
   background-color: $red;
   color: $base;
@@ -202,16 +221,6 @@
   color: $text;
 }
 
-progressbar,
-progress,
-trough {
-  border-radius: 12.6px;
-}
-
-progressbar {
-  box-shadow: inset 0 0 0 1px $surface1;
-}
-
 .notification.critical progress {
   background-color: $red;
 }
@@ -219,14 +228,6 @@ progressbar {
 .notification.low progress,
 .notification.normal progress {
   background-color: $blue;
-}
-
-trough {
-  background-color: $surface0;
-}
-
-.control-center trough {
-  background-color: $surface1;
 }
 
 .control-center-dnd {
@@ -267,4 +268,79 @@ trough {
   background: $surface1;
   border-radius: 8px;
   border: 1px solid $overlay0;
+}
+
+.widget-mpris .widget-mpris-player {
+    background: $surface0;
+    padding: 7px;
+}
+
+.widget-mpris .widget-mpris-title {
+    font-size: 1.2rem;
+}
+
+.widget-mpris .widget-mpris-subtitle {
+    font-size: 0.8rem;
+}
+
+.widget-menubar>box>.menu-button-bar>button>label {
+    font-size: 3rem;
+    padding: 0.5rem 2rem;
+}
+
+.widget-menubar>box>.menu-button-bar>:last-child {
+    color: $red;
+}
+
+.power-buttons,
+.powermode-buttons,
+.screenshot-buttons {
+
+}
+.power-buttons button:hover,
+.powermode-buttons button:hover,
+.screenshot-buttons button:hover {
+    background: $surface0;
+}
+
+.control-center .widget-label>label {
+  color: $text;
+  font-size: 2rem;
+}
+
+.widget-buttons-grid {
+    padding-top: 1rem;
+}
+
+.widget-buttons-grid>flowbox>flowboxchild>button label {
+    font-size: 2.5rem;
+}
+
+.widget-volume {
+    padding-top: 1rem;
+}
+
+.widget-volume label {
+    font-size: 1.5rem;
+    color: $sapphire;
+}
+
+.widget-volume trough highlight {
+    background: $sapphire;
+}
+
+.widget-backlight trough highlight {
+    background: $yellow;
+}
+.widget-backlight scale {
+    margin-right: 1rem;
+}
+
+.widget-backlight label {
+    font-size: 1.5rem;
+    color: $yellow;
+}
+
+.widget-backlight .KB {
+    padding-bottom: 1rem;
 }


### PR DESCRIPTION
Included widgets are:
- button grid
- menu buttons (dropdown is kind of meh)
- volume (not per app)
- backlight
- mpris

I think I removed all the changes like removing border-radius etc., so that you can focus more on just tweaking new things.
What I have barely touched so far is:
- Expendables (from per-app volume and menubar actions).
- some detail like mpris player select arrow, as I just found out the inspector runs on `swaync` not `swaync-client` and didn't have the time yet.
If you want, I can provide my config so you don't have to do one yourself, but you can also get one [here.](https://github.com/ErikReider/SwayNotificationCenter/discussions/183)