### PR TITLE
feat!: revamp and support swaync 0.12.1

### DIFF
--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -22,6 +22,17 @@ slider {
 
 /* notifications */
 
+.notification-background {
+  box-shadow:
+    0 0 8px 0 rgba(0, 0, 0, 0.8),
+    inset 0 0 0 1px $surface0;
+  border-radius: 12.6px;
+  margin: 18px;
+  background-color: $base;
+  color: $text;
+  padding: 0;
+}
+
 .notification-background .notification {
   padding: 7px;
   border-radius: 12.6px;
@@ -33,6 +44,11 @@ slider {
 
 .notification .notification-content {
   margin: 7px;
+}
+
+.notification .notification-content overlay {
+  /* icons */
+  margin: 4px;
 }
 
 .notification-content .summary {
@@ -108,19 +124,6 @@ slider {
   background-color: $surface0;
 }
 
-/* floating notifications */
-
-.floating-notifications .notification-background {
-  box-shadow:
-    0 0 8px 0 rgba(0, 0, 0, 0.8),
-    inset 0 0 0 1px $surface0;
-  border-radius: 12.6px;
-  margin: 18px;
-  background-color: $base;
-  color: $text;
-  padding: 0;
-}
-
 /* control center */
 
 .control-center {
@@ -132,6 +135,16 @@ slider {
   background-color: $base;
   color: $text;
   padding: 14px;
+}
+
+.control-center .notification-background {
+  border-radius: 7px;
+  box-shadow: inset 0 0 0 1px $surface1;
+  margin: 10px 0;
+}
+
+.control-center .notification-background .notification {
+  border-radius: 7px;
 }
 
 .control-center .widget-title > label {
@@ -153,18 +166,6 @@ slider {
 
 .control-center .widget-title button:active {
   background-color: $surface2;
-}
-
-.control-center .notification-row .notification-background {
-  border-radius: 7px;
-  color: $text;
-  background-color: $base;
-  box-shadow: inset 0 0 0 1px $surface1;
-  margin-top: 14px;
-}
-
-.control-center .notification-background .notification {
-  border-radius: 7px;
 }
 
 /* dnd */

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -152,7 +152,7 @@ trough {
 .control-center .notification-background {
   border-radius: 7px;
   box-shadow: inset 0 0 0 1px $surface1;
-  margin: 10px 0;
+  margin: 4px 10px;
 }
 
 .control-center .notification-background .notification {
@@ -182,6 +182,19 @@ trough {
 
 .control-center .widget-title button:active {
   background-color: $surface2;
+}
+
+.control-center .notification-group {
+  margin-top: 10px;
+}
+
+scrollbar slider {
+  margin: -3px;
+  opacity: 0.8;
+}
+
+scrollbar trough {
+  margin: 2px 0;
 }
 
 /* dnd */

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -144,7 +144,6 @@ trough {
     0 0 8px 0 rgba(0, 0, 0, 0.8),
     inset 0 0 0 1px $surface0;
   border-radius: 12.6px;
-  margin: 18px;
   background-color: $base;
   color: $text;
   padding: 14px;

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -83,6 +83,17 @@ slider {
   background-color: $blue;
 }
 
+.notification progress,
+.notification trough,
+.notification progressbar {
+  border-radius: 12.6px;
+  padding: 3px 0;
+}
+
+.notification trough {
+  background-color: $surface0;
+}
+
 /* floating notifications */
 
 .floating-notifications .notification-background {

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -6,22 +6,24 @@
 }
 
 trough highlight {
-    background: $text;
+  background: $text;
 }
 
 scale trough {
-    margin: 0rem 1rem;
-    background-color: $surface0;
-    min-height: 8px;
-    min-width: 70px;
+  margin: 0rem 1rem;
+  background-color: $surface0;
+  min-height: 8px;
+  min-width: 70px;
 }
 
 slider {
-    background-color: $blue;
+  background-color: $blue;
 }
 
 .floating-notifications.background .notification-row .notification-background {
-  box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.8), inset 0 0 0 1px $surface0;
+  box-shadow:
+    0 0 8px 0 rgba(0, 0, 0, 0.8),
+    inset 0 0 0 1px $surface0;
   border-radius: 12.6px;
   margin: 18px;
   background-color: $base;
@@ -29,36 +31,72 @@ slider {
   padding: 0;
 }
 
-.floating-notifications.background .notification-row .notification-background .notification {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .notification {
   padding: 7px;
   border-radius: 12.6px;
 }
 
-.floating-notifications.background .notification-row .notification-background .notification.critical {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .notification.critical {
   box-shadow: inset 0 0 7px 0 $red;
 }
 
-.floating-notifications.background .notification-row .notification-background .notification .notification-content {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .notification
+  .notification-content {
   margin: 7px;
 }
 
-.floating-notifications.background .notification-row .notification-background .notification .notification-content .summary {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .notification
+  .notification-content
+  .summary {
   color: $text;
 }
 
-.floating-notifications.background .notification-row .notification-background .notification .notification-content .time {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .notification
+  .notification-content
+  .time {
   color: $subtext0;
 }
 
-.floating-notifications.background .notification-row .notification-background .notification .notification-content .body {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .notification
+  .notification-content
+  .body {
   color: $text;
 }
 
-.floating-notifications.background .notification-row .notification-background .notification>*:last-child>* {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .notification
+  > *:last-child
+  > * {
   min-height: 3.4em;
 }
 
-.floating-notifications.background .notification-row .notification-background .notification>*:last-child>* .notification-action {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .notification
+  > *:last-child
+  > *
+  .notification-action {
   border-radius: 7px;
   color: $text;
   background-color: $surface0;
@@ -66,19 +104,34 @@ slider {
   margin: 7px;
 }
 
-.floating-notifications.background .notification-row .notification-background .notification>*:last-child>* .notification-action:hover {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .notification
+  > *:last-child
+  > *
+  .notification-action:hover {
   box-shadow: inset 0 0 0 1px $surface1;
   background-color: $surface0;
   color: $text;
 }
 
-.floating-notifications.background .notification-row .notification-background .notification>*:last-child>* .notification-action:active {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .notification
+  > *:last-child
+  > *
+  .notification-action:active {
   box-shadow: inset 0 0 0 1px $surface1;
   background-color: $sapphire;
   color: $text;
 }
 
-.floating-notifications.background .notification-row .notification-background .close-button {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .close-button {
   margin: 7px;
   padding: 2px;
   border-radius: 6.3px;
@@ -86,18 +139,26 @@ slider {
   background-color: $red;
 }
 
-.floating-notifications.background .notification-row .notification-background .close-button:hover {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .close-button:hover {
   background-color: $maroon;
   color: $base;
 }
 
-.floating-notifications.background .notification-row .notification-background .close-button:active {
+.floating-notifications.background
+  .notification-row
+  .notification-background
+  .close-button:active {
   background-color: $red;
   color: $base;
 }
 
 .control-center {
-  box-shadow: 0 0 8px 0 rgba(0, 0, 0, 0.8), inset 0 0 0 1px $surface0;
+  box-shadow:
+    0 0 8px 0 rgba(0, 0, 0, 0.8),
+    inset 0 0 0 1px $surface0;
   border-radius: 12.6px;
   margin: 18px;
   background-color: $base;
@@ -105,7 +166,7 @@ slider {
   padding: 14px;
 }
 
-.control-center .widget-title>label {
+.control-center .widget-title > label {
   color: $text;
   font-size: 1.3em;
 }
@@ -143,31 +204,64 @@ slider {
   border-radius: 7px;
 }
 
-.control-center .notification-row .notification-background .notification.critical {
+.control-center
+  .notification-row
+  .notification-background
+  .notification.critical {
   box-shadow: inset 0 0 7px 0 $red;
 }
 
-.control-center .notification-row .notification-background .notification .notification-content {
+.control-center
+  .notification-row
+  .notification-background
+  .notification
+  .notification-content {
   margin: 7px;
 }
 
-.control-center .notification-row .notification-background .notification .notification-content .summary {
+.control-center
+  .notification-row
+  .notification-background
+  .notification
+  .notification-content
+  .summary {
   color: $text;
 }
 
-.control-center .notification-row .notification-background .notification .notification-content .time {
+.control-center
+  .notification-row
+  .notification-background
+  .notification
+  .notification-content
+  .time {
   color: $subtext0;
 }
 
-.control-center .notification-row .notification-background .notification .notification-content .body {
+.control-center
+  .notification-row
+  .notification-background
+  .notification
+  .notification-content
+  .body {
   color: $text;
 }
 
-.control-center .notification-row .notification-background .notification>*:last-child>* {
+.control-center
+  .notification-row
+  .notification-background
+  .notification
+  > *:last-child
+  > * {
   min-height: 3.4em;
 }
 
-.control-center .notification-row .notification-background .notification>*:last-child>* .notification-action {
+.control-center
+  .notification-row
+  .notification-background
+  .notification
+  > *:last-child
+  > *
+  .notification-action {
   border-radius: 7px;
   color: $text;
   background-color: $crust;
@@ -175,13 +269,25 @@ slider {
   margin: 7px;
 }
 
-.control-center .notification-row .notification-background .notification>*:last-child>* .notification-action:hover {
+.control-center
+  .notification-row
+  .notification-background
+  .notification
+  > *:last-child
+  > *
+  .notification-action:hover {
   box-shadow: inset 0 0 0 1px $surface1;
   background-color: $surface0;
   color: $text;
 }
 
-.control-center .notification-row .notification-background .notification>*:last-child>* .notification-action:active {
+.control-center
+  .notification-row
+  .notification-background
+  .notification
+  > *:last-child
+  > *
+  .notification-action:active {
   box-shadow: inset 0 0 0 1px $surface1;
   background-color: $sapphire;
   color: $text;
@@ -204,7 +310,10 @@ slider {
   color: $base;
 }
 
-.control-center .notification-row .notification-background .close-button:active {
+.control-center
+  .notification-row
+  .notification-background
+  .close-button:active {
   background-color: $red;
   color: $base;
 }
@@ -252,7 +361,7 @@ slider {
   font-size: 1.1rem;
 }
 
-.widget-dnd>switch {
+.widget-dnd > switch {
   font-size: initial;
   border-radius: 8px;
   background: $surface0;
@@ -260,81 +369,81 @@ slider {
   box-shadow: none;
 }
 
-.widget-dnd>switch:checked {
+.widget-dnd > switch:checked {
   background: $surface0;
 }
 
-.widget-dnd>switch slider {
+.widget-dnd > switch slider {
   background: $surface1;
   border-radius: 8px;
   border: 1px solid $overlay0;
 }
 
 .widget-mpris .widget-mpris-player {
-    background: $surface0;
-    padding: 7px;
+  background: $surface0;
+  padding: 7px;
 }
 
 .widget-mpris .widget-mpris-title {
-    font-size: 1.2rem;
+  font-size: 1.2rem;
 }
 
 .widget-mpris .widget-mpris-subtitle {
-    font-size: 0.8rem;
+  font-size: 0.8rem;
 }
 
-.widget-menubar>box>.menu-button-bar>button>label {
-    font-size: 3rem;
-    padding: 0.5rem 2rem;
+.widget-menubar > box > .menu-button-bar > button > label {
+  font-size: 3rem;
+  padding: 0.5rem 2rem;
 }
 
-.widget-menubar>box>.menu-button-bar>:last-child {
-    color: $red;
+.widget-menubar > box > .menu-button-bar > :last-child {
+  color: $red;
 }
 
 .power-buttons button:hover,
 .powermode-buttons button:hover,
 .screenshot-buttons button:hover {
-    background: $surface0;
+  background: $surface0;
 }
 
-.control-center .widget-label>label {
+.control-center .widget-label > label {
   color: $text;
   font-size: 2rem;
 }
 
 .widget-buttons-grid {
-    padding-top: 1rem;
+  padding-top: 1rem;
 }
 
-.widget-buttons-grid>flowbox>flowboxchild>button label {
-    font-size: 2.5rem;
+.widget-buttons-grid > flowbox > flowboxchild > button label {
+  font-size: 2.5rem;
 }
 
 .widget-volume {
-    padding-top: 1rem;
+  padding-top: 1rem;
 }
 
 .widget-volume label {
-    font-size: 1.5rem;
-    color: $sapphire;
+  font-size: 1.5rem;
+  color: $sapphire;
 }
 
 .widget-volume trough highlight {
-    background: $sapphire;
+  background: $sapphire;
 }
 
 .widget-backlight trough highlight {
-    background: $yellow;
+  background: $yellow;
 }
 
 .widget-backlight label {
-    font-size: 1.5rem;
-    color: $yellow;
+  font-size: 1.5rem;
+  color: $yellow;
 }
 
 .widget-backlight .KB {
-    padding-bottom: 1rem;
+  padding-bottom: 1rem;
 }
 
 .image {

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -44,7 +44,7 @@ slider {
 }
 
 .notification-content .body {
-  color: $text;
+  color: $subtext1;
 }
 
 .notification > *:last-child > * {

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -159,6 +159,10 @@ trough {
   border-radius: 7px;
 }
 
+.control-center .notification-background .notification.low {
+  opacity: 0.8;
+}
+
 .control-center .widget-title > label {
   color: $text;
   font-size: 1.3em;

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -177,25 +177,11 @@ slider {
   background-color: $overlay2;
 }
 
-.control-center-dnd {
-  margin-top: 5px;
-  border-radius: 8px;
-  background: $surface0;
-  border: 1px solid $surface1;
-  box-shadow: none;
-}
-
-.control-center-dnd:checked {
-  background: $surface0;
-}
-
-.control-center-dnd slider {
-  background: $surface1;
-  border-radius: 8px;
-}
+/* dnd */
 
 .widget-dnd {
-  margin: 0px;
+  margin-top: 5px;
+  border-radius: 8px;
   font-size: 1.1rem;
 }
 
@@ -203,18 +189,16 @@ slider {
   font-size: initial;
   border-radius: 8px;
   background: $surface0;
-  border: 1px solid $surface1;
   box-shadow: none;
 }
 
 .widget-dnd > switch:checked {
-  background: $surface0;
+  background: $blue;
 }
 
 .widget-dnd > switch slider {
   background: $surface1;
   border-radius: 8px;
-  border: 1px solid $overlay0;
 }
 
 .widget-mpris .widget-mpris-player {

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -71,7 +71,21 @@ slider {
   border-radius: 7px;
   color: $text;
   box-shadow: inset 0 0 0 1px $surface1;
-  margin: 7px;
+  margin: 4px;
+  padding: 8px;
+  font-size: 0.2rem; /* controls the button size not text size*/
+}
+
+.notification .notification-action {
+  background-color: $surface0;
+}
+
+.notification .notification-action:hover {
+  background-color: $surface1;
+}
+
+.notification .notification-action:active {
+  background-color: $surface2;
 }
 
 .notification.critical progress {
@@ -105,18 +119,6 @@ slider {
   background-color: $base;
   color: $text;
   padding: 0;
-}
-
-.floating-notifications .notification .notification-action {
-  background-color: $surface0;
-}
-
-.floating-notifications .notification .notification-action:hover {
-  background-color: $surface1;
-}
-
-.floating-notifications .notification-action:active {
-  background-color: $surface2;
 }
 
 /* control center */
@@ -163,18 +165,6 @@ slider {
 
 .control-center .notification-background .notification {
   border-radius: 7px;
-}
-
-.control-center .notification-action {
-  background-color: $overlay0;
-}
-
-.control-center .notification-action:hover {
-  background-color: $overlay1;
-}
-
-.control-center .notification-action:active {
-  background-color: $overlay2;
 }
 
 /* dnd */

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -20,7 +20,72 @@ slider {
   background-color: $blue;
 }
 
-.floating-notifications.background .notification-row .notification-background {
+/* notifications */
+
+.notification-background .notification {
+  padding: 7px;
+  border-radius: 12.6px;
+}
+
+.notification-background .notification.critical {
+  box-shadow: inset 0 0 7px 0 $red;
+}
+
+.notification .notification-content {
+  margin: 7px;
+}
+
+.notification-content .summary {
+  color: $text;
+}
+
+.notification-content .time {
+  color: $subtext0;
+}
+
+.notification-content .body {
+  color: $text;
+}
+
+.notification > *:last-child > * {
+  min-height: 3.4em;
+}
+
+.notification-background .close-button {
+  margin: 7px;
+  padding: 2px;
+  border-radius: 6.3px;
+  color: $base;
+  background-color: $red;
+}
+
+.notification-background .close-button:hover {
+  background-color: $maroon;
+}
+
+.notification-background .close-button:active {
+  background-color: $pink;
+}
+
+.notification .notification-action {
+  border-radius: 7px;
+  color: $text;
+  box-shadow: inset 0 0 0 1px $surface1;
+  margin: 7px;
+}
+
+.notification.critical progress {
+  background-color: $red;
+}
+
+.notification.low progress,
+.notification.normal progress {
+  background-color: $blue;
+}
+
+/* floating notifications */
+
+.floating-notifications .notification-background {
   box-shadow:
     0 0 8px 0 rgba(0, 0, 0, 0.8),
     inset 0 0 0 1px $surface0;
@@ -31,129 +96,19 @@ slider {
   padding: 0;
 }
 
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .notification {
-  padding: 7px;
-  border-radius: 12.6px;
-}
-
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .notification.critical {
-  box-shadow: inset 0 0 7px 0 $red;
-}
-
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .notification
-  .notification-content {
-  margin: 7px;
-}
-
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .notification
-  .notification-content
-  .summary {
-  color: $text;
-}
-
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .notification
-  .notification-content
-  .time {
-  color: $subtext0;
-}
-
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .notification
-  .notification-content
-  .body {
-  color: $text;
-}
-
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .notification
-  > *:last-child
-  > * {
-  min-height: 3.4em;
-}
-
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .notification
-  > *:last-child
-  > *
-  .notification-action {
-  border-radius: 7px;
-  color: $text;
+.floating-notifications .notification .notification-action {
   background-color: $surface0;
-  box-shadow: inset 0 0 0 1px $surface1;
-  margin: 7px;
 }
 
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .notification
-  > *:last-child
-  > *
-  .notification-action:hover {
-  box-shadow: inset 0 0 0 1px $surface1;
-  background-color: $surface0;
-  color: $text;
+.floating-notifications .notification .notification-action:hover {
+  background-color: $surface1;
 }
 
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .notification
-  > *:last-child
-  > *
-  .notification-action:active {
-  box-shadow: inset 0 0 0 1px $surface1;
-  background-color: $sapphire;
-  color: $text;
+.floating-notifications .notification-action:active {
+  background-color: $surface2;
 }
 
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .close-button {
-  margin: 7px;
-  padding: 2px;
-  border-radius: 6.3px;
-  color: $base;
-  background-color: $red;
-}
-
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .close-button:hover {
-  background-color: $maroon;
-  color: $base;
-}
-
-.floating-notifications.background
-  .notification-row
-  .notification-background
-  .close-button:active {
-  background-color: $red;
-  color: $base;
-}
+/* control center */
 
 .control-center {
   box-shadow:
@@ -180,163 +135,35 @@ slider {
 }
 
 .control-center .widget-title button:hover {
-  box-shadow: inset 0 0 0 1px $surface1;
-  background-color: $surface2;
-  color: $text;
+  background-color: $surface1;
 }
 
 .control-center .widget-title button:active {
-  box-shadow: inset 0 0 0 1px $surface1;
-  background-color: $sapphire;
-  color: $base;
+  background-color: $surface2;
 }
 
 .control-center .notification-row .notification-background {
   border-radius: 7px;
   color: $text;
-  background-color: $surface0;
+  background-color: $base;
   box-shadow: inset 0 0 0 1px $surface1;
   margin-top: 14px;
 }
 
-.control-center .notification-row .notification-background .notification {
-  padding: 7px;
+.control-center .notification-background .notification {
   border-radius: 7px;
 }
 
-.control-center
-  .notification-row
-  .notification-background
-  .notification.critical {
-  box-shadow: inset 0 0 7px 0 $red;
+.control-center .notification-action {
+  background-color: $overlay0;
 }
 
-.control-center
-  .notification-row
-  .notification-background
-  .notification
-  .notification-content {
-  margin: 7px;
-}
-
-.control-center
-  .notification-row
-  .notification-background
-  .notification
-  .notification-content
-  .summary {
-  color: $text;
-}
-
-.control-center
-  .notification-row
-  .notification-background
-  .notification
-  .notification-content
-  .time {
-  color: $subtext0;
-}
-
-.control-center
-  .notification-row
-  .notification-background
-  .notification
-  .notification-content
-  .body {
-  color: $text;
-}
-
-.control-center
-  .notification-row
-  .notification-background
-  .notification
-  > *:last-child
-  > * {
-  min-height: 3.4em;
-}
-
-.control-center
-  .notification-row
-  .notification-background
-  .notification
-  > *:last-child
-  > *
-  .notification-action {
-  border-radius: 7px;
-  color: $text;
-  background-color: $crust;
-  box-shadow: inset 0 0 0 1px $surface1;
-  margin: 7px;
-}
-
-.control-center
-  .notification-row
-  .notification-background
-  .notification
-  > *:last-child
-  > *
-  .notification-action:hover {
-  box-shadow: inset 0 0 0 1px $surface1;
-  background-color: $surface0;
-  color: $text;
-}
-
-.control-center
-  .notification-row
-  .notification-background
-  .notification
-  > *:last-child
-  > *
-  .notification-action:active {
-  box-shadow: inset 0 0 0 1px $surface1;
-  background-color: $sapphire;
-  color: $text;
-}
-
-.control-center .notification-row .notification-background .close-button {
-  margin: 7px;
-  padding: 2px;
-  border-radius: 6.3px;
-  color: $base;
-  background-color: $maroon;
-}
-
-.close-button {
-  border-radius: 6.3px;
-}
-
-.control-center .notification-row .notification-background .close-button:hover {
-  background-color: $red;
-  color: $base;
-}
-
-.control-center
-  .notification-row
-  .notification-background
-  .close-button:active {
-  background-color: $red;
-  color: $base;
-}
-
-.control-center .notification-row .notification-background:hover {
-  box-shadow: inset 0 0 0 1px $surface1;
+.control-center .notification-action:hover {
   background-color: $overlay1;
-  color: $text;
 }
 
-.control-center .notification-row .notification-background:active {
-  box-shadow: inset 0 0 0 1px $surface1;
-  background-color: $sapphire;
-  color: $text;
-}
-
-.notification.critical progress {
-  background-color: $red;
-}
-
-.notification.low progress,
-.notification.normal progress {
-  background-color: $blue;
+.control-center .notification-action:active {
+  background-color: $overlay2;
 }
 
 .control-center-dnd {

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -204,17 +204,57 @@ trough {
   border-radius: 8px;
 }
 
-.widget-mpris .widget-mpris-player {
+/* mpris */
+
+.widget-mpris-player {
   background: $surface0;
-  padding: 7px;
+  border-radius: 12.6px;
+  color: #cdd6f4;
 }
 
-.widget-mpris .widget-mpris-title {
+.mpris-overlay {
+  background-color: $surface0;
+  opacity: 0.9;
+  padding: 15px 10px;
+}
+
+.widget-mpris-album-art {
+  -gtk-icon-size: 100px;
+  border-radius: 12.6px;
+  margin: 0 10px;
+}
+
+.widget-mpris-title {
   font-size: 1.2rem;
+  color: $text;
 }
 
-.widget-mpris .widget-mpris-subtitle {
-  font-size: 0.8rem;
+.widget-mpris-subtitle {
+  font-size: 1rem;
+  color: $subtext1;
+}
+
+.widget-mpris button {
+  border-radius: 12.6px;
+  color: $text;
+  margin: 0 5px;
+  padding: 2px;
+}
+
+.widget-mpris button image {
+  -gtk-icon-size: 1.8rem;
+}
+
+.widget-mpris button:hover {
+  background-color: $surface0;
+}
+
+.widget-mpris button:active {
+  background-color: $surface1;
+}
+
+.widget-mpris button:disabled {
+  opacity: 0.5;
 }
 
 .widget-menubar > box > .menu-button-bar > button > label {

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -43,10 +43,10 @@ trough {
 .notification-background {
   box-shadow:
     0 0 8px 0 rgba(0, 0, 0, 0.8),
-    inset 0 0 0 1px $surface0;
+    inset 0 0 0 1px $surface1;
   border-radius: 12.6px;
   margin: 18px;
-  background-color: $base;
+  background: $mantle;
   color: $text;
   padding: 0;
 }

--- a/src/_theme.scss
+++ b/src/_theme.scss
@@ -9,15 +9,33 @@ trough highlight {
   background: $text;
 }
 
-scale trough {
-  margin: 0rem 1rem;
-  background-color: $surface0;
-  min-height: 8px;
-  min-width: 70px;
+scale {
+  margin: 0 7px;
 }
 
-slider {
+scale trough {
+  margin: 0rem 1rem;
+  min-height: 8px;
+  min-width: 70px;
+  border-radius: 12.6px;
+}
+
+trough slider {
+  margin: -10px;
+  border-radius: 12.6px;
+  box-shadow: 0 0 2px rgba(0, 0, 0, 0.8);
+  transition: all 0.2s ease;
   background-color: $blue;
+}
+
+trough slider:hover {
+  box-shadow:
+    0 0 2px rgba(0, 0, 0, 0.8),
+    0 0 8px $blue;
+}
+
+trough {
+  background-color: $surface0;
 }
 
 /* notifications */
@@ -119,11 +137,6 @@ slider {
   border-radius: 12.6px;
   padding: 3px 0;
 }
-
-.notification trough {
-  background-color: $surface0;
-}
-
 /* control center */
 
 .control-center {
@@ -234,12 +247,12 @@ slider {
 }
 
 .widget-volume {
-  padding-top: 1rem;
+  padding: 1rem 0;
 }
 
 .widget-volume label {
-  font-size: 1.5rem;
   color: $sapphire;
+  padding: 0 1rem;
 }
 
 .widget-volume trough highlight {


### PR DESCRIPTION
changes of this PR:
- cleanup of redundant css selectors
- unified some floating & control-center selectors
- fixed `progressbar` not showing
- fixed slider not showing animations and handle (volume & backlight)
- added blue `dnd` on checked
- fixed & revamped mpris widget
- fixed scrollbar blocking notifications

**old**
<img width="545" height="643" alt="old" src="https://github.com/user-attachments/assets/bfa23cb1-6756-4531-96a2-878835de4bca" />

**new**
<img width="536" height="639" alt="new" src="https://github.com/user-attachments/assets/76755d4b-be1a-48dc-85b8-1091e60fd4ec" />

pls. review.